### PR TITLE
New feature: show/hide tooltips with a button

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ The easiest way is to use the `@Extension` annotation on a [LoggingTooltipExtens
             new LoggingTooltipExtension(loggers, Level.FINE, false);
 ```
 
+The ability to show/hide the tooltip with a Button has also been added:
+
+```java
+        Button myButton = new Button("Show/hide tooltip");
+        extension.setToggleTooltipButton(myButton);
+```
+
 ## Using other loggers
 
 For those not using java.util.logging, a custom LogMessenger can be provided. See the test class [AlternateLoggingTooltipExtensionFactory](https://github.com/concordion/concordion-extensions/blob/master/src/test/java/spec/concordion/ext/loggingTooltip/AlternateLoggingTooltipExtensionFactory.java) for a basic example.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,22 @@ The easiest way is to use the `@Extension` annotation on a [LoggingTooltipExtens
             new LoggingTooltipExtension(loggers, Level.FINE, false);
 ```
 
-The ability to show/hide the tooltip with a Button has also been added:
+The ability to show/hide the tooltip with a button has also been added (either in Java or JavaScript):
 
+* In Java:
 ```java
-        Button myButton = new Button("Show/hide tooltip");
-        extension.setToggleTooltipButton(myButton);
+        @Extension
+        LoggingTooltipExtension extension = new LoggingTooltipExtension();
+        
+        // By implementing the TooltipButton interface
+        TooltipButton myButton = new ToggleTooltipButton();
+        extension.setTooltipButton(myButton);
+```
+
+* In JavaScript:
+```html
+        <!-- By calling the toggleTooltip() function -->
+        <input type="button" onclick="toggleTooltip();" value="Toggle tooltip" />
 ```
 
 ## Using other loggers

--- a/src/main/java/org/concordion/ext/LoggingTooltipExtension.java
+++ b/src/main/java/org/concordion/ext/LoggingTooltipExtension.java
@@ -14,8 +14,11 @@
  */
 package org.concordion.ext;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.awt.Button;
 
 import org.concordion.api.Resource;
 import org.concordion.api.extension.ConcordionExtender;
@@ -39,7 +42,7 @@ import org.concordion.ext.tooltip.TooltipRenderer;
  *
  * <p>Thanks to Trent Richardson for the <a href="http://trentrichardson.com/examples/csstooltips/">CSS Tooltip</a> implementation.</p>
  */
-public class LoggingTooltipExtension implements ConcordionExtension {
+public class LoggingTooltipExtension implements ConcordionExtension, ActionListener {
 
     private static final String TOOLTIP_CSS_SOURCE_PATH = "/org/concordion/ext/resource/tooltip.css";
     private static final Resource TOOLTIP_CSS_TARGET_RESOURCE = new Resource("/tooltip.css");
@@ -52,6 +55,9 @@ public class LoggingTooltipExtension implements ConcordionExtension {
     private static final String INFO_RESOURCE_PATH = "/org/concordion/ext/resource/i16.png";
 
     private final LogMessenger logMessenger;
+
+    private Button toggleTooltipButton = null;
+    private boolean showTooltip = true;
 
     /**
      * Default constructor that logs output from all java.util.loggers, with a {@link Level} of <code>INFO</code> or higher, and disables the console output of the root logger.
@@ -81,9 +87,23 @@ public class LoggingTooltipExtension implements ConcordionExtension {
         this.logMessenger = new JavaUtilLogMessenger(loggerNames, loggingLevel, displayRootConsoleLogging);
     }
 
+    /**
+     * Permits to use a button to show/hide the tooltip
+     *
+     * @param toggleTooltipButton button to show/hide the tooltip when clicked
+     */
+    public void setToggleTooltipButton(Button toggleTooltipButton) {
+        this.toggleTooltipButton = toggleTooltipButton;
+    }
+
     @Override
     public void addTo(ConcordionExtender concordionExtender) {
-        LogMessageTooltipWriter extension = new LogMessageTooltipWriter(new TooltipRenderer(INFO_IMAGE_RESOURCE), logMessenger);
+        LogMessageTooltipWriter extension = new LogMessageTooltipWriter(new TooltipRenderer(INFO_IMAGE_RESOURCE), logMessenger, showTooltip);
+
+        if(this.toggleTooltipButton != null) {
+            this.toggleTooltipButton.addActionListener(this);
+            this.toggleTooltipButton.addActionListener(extension);
+        }
 
         concordionExtender.withExecuteListener(extension).withAssertEqualsListener(extension).withAssertTrueListener(extension)
                 .withAssertFalseListener(extension).withVerifyRowsListener(extension).withThrowableListener(extension);
@@ -94,4 +114,8 @@ public class LoggingTooltipExtension implements ConcordionExtension {
         concordionExtender.withResource(INFO_RESOURCE_PATH, INFO_IMAGE_RESOURCE);
     }
 
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        showTooltip = !showTooltip;
+    }
 }

--- a/src/main/java/org/concordion/ext/logging/LogMessageTooltipWriter.java
+++ b/src/main/java/org/concordion/ext/logging/LogMessageTooltipWriter.java
@@ -14,6 +14,9 @@
  */
 package org.concordion.ext.logging;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
 import org.concordion.api.Element;
 import org.concordion.api.Resource;
 import org.concordion.api.listener.AssertEqualsListener;
@@ -37,15 +40,21 @@ import org.concordion.ext.tooltip.TooltipRenderer;
  * Writes any new log messages to tooltips when invoked by Concordion events.   
  */
 public class LogMessageTooltipWriter implements AssertEqualsListener, AssertTrueListener, AssertFalseListener, ExecuteListener,
-        SpecificationProcessingListener, VerifyRowsListener, ThrowableCaughtListener {
+        SpecificationProcessingListener, VerifyRowsListener, ThrowableCaughtListener, ActionListener {
 
     private final TooltipRenderer renderer;
     private final LogMessenger logMessenger;
     private Resource resource;
+    private boolean showTooltip;
 
     public LogMessageTooltipWriter(TooltipRenderer renderer, LogMessenger logMessenger) {
         this.logMessenger = logMessenger;
         this.renderer = renderer;
+    }
+
+    public LogMessageTooltipWriter(TooltipRenderer renderer, LogMessenger logMessenger, boolean showTooltip) {
+        this(renderer, logMessenger);
+        this.showTooltip = showTooltip;
     }
 
     @Override
@@ -91,10 +100,18 @@ public class LogMessageTooltipWriter implements AssertEqualsListener, AssertTrue
     public void surplusRow(SurplusRowEvent event) {
     }
 
+    /**
+     * Possibility to hide/show the tooltip when an action event is fired
+     */
+    @Override
+    public void actionPerformed(ActionEvent event) {
+        showTooltip = !showTooltip;
+    }
+
     private void renderLogMessages(Element element) {
         String text = logMessenger.getNewLogMessages();
 
-        if (text.length() > 0) {
+        if (text.length() > 0 && showTooltip) {
             renderer.renderTooltip(resource, element, text);
         }
     }

--- a/src/main/java/org/concordion/ext/logging/LogMessageTooltipWriter.java
+++ b/src/main/java/org/concordion/ext/logging/LogMessageTooltipWriter.java
@@ -16,6 +16,8 @@ package org.concordion.ext.logging;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.concordion.api.Element;
 import org.concordion.api.Resource;
@@ -45,16 +47,18 @@ public class LogMessageTooltipWriter implements AssertEqualsListener, AssertTrue
     private final TooltipRenderer renderer;
     private final LogMessenger logMessenger;
     private Resource resource;
-    private boolean showTooltip;
+    private List<Element> tooltips;
+    private boolean displayTooltip = true;
 
     public LogMessageTooltipWriter(TooltipRenderer renderer, LogMessenger logMessenger) {
         this.logMessenger = logMessenger;
         this.renderer = renderer;
+        this.tooltips = new ArrayList<>();
     }
 
-    public LogMessageTooltipWriter(TooltipRenderer renderer, LogMessenger logMessenger, boolean showTooltip) {
+    public LogMessageTooltipWriter(TooltipRenderer renderer, LogMessenger logMessenger, boolean displayTooltip) {
         this(renderer, logMessenger);
-        this.showTooltip = showTooltip;
+        this.displayTooltip = displayTooltip;
     }
 
     @Override
@@ -100,19 +104,23 @@ public class LogMessageTooltipWriter implements AssertEqualsListener, AssertTrue
     public void surplusRow(SurplusRowEvent event) {
     }
 
-    /**
-     * Possibility to hide/show the tooltip when an action event is fired
-     */
-    @Override
-    public void actionPerformed(ActionEvent event) {
-        showTooltip = !showTooltip;
-    }
-
     private void renderLogMessages(Element element) {
         String text = logMessenger.getNewLogMessages();
 
-        if (text.length() > 0 && showTooltip) {
-            renderer.renderTooltip(resource, element, text);
+        if (text.length() > 0) {
+            Element tt = renderer.renderTooltip(resource, element, text, displayTooltip);
+            tooltips.add(tt);
+        }
+    }
+
+    /**
+     * Show/Hide the tooltip when an ActionEvent is fired
+     */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        displayTooltip = !displayTooltip;
+        for(Element tt : tooltips) {
+            renderer.setTooltipDisplay(tt, displayTooltip);
         }
     }
 }

--- a/src/main/java/org/concordion/ext/tooltip/TooltipButton.java
+++ b/src/main/java/org/concordion/ext/tooltip/TooltipButton.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010 Two Ten Consulting Limited, New Zealand 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.concordion.ext.tooltip;
+
+import java.awt.event.ActionListener;
+
+public interface TooltipButton {
+    public void addActionListener(ActionListener l);
+    public void removeActionListener(ActionListener l);
+    public ActionListener[] getActionListeners();
+}

--- a/src/main/java/org/concordion/ext/tooltip/TooltipRenderer.java
+++ b/src/main/java/org/concordion/ext/tooltip/TooltipRenderer.java
@@ -49,10 +49,10 @@ public class TooltipRenderer {
      * @param element the element that the tooltip is to be added to
      * @param text the text to include in the tooltip
      */
-    public void renderTooltip(Resource resource, Element element, String text) {
+    public Element renderTooltip(Resource resource, Element element, String text, boolean displayTooltip) {
         buttonId++;
         
-        Element tooltip = createTooltip(resource.getRelativePath(tooltipImageResource), text);
+        Element tooltip = createTooltip(resource.getRelativePath(tooltipImageResource), text, displayTooltip);
         if (element.getLocalName().equals("table")) {
             Element tr = element.getFirstDescendantNamed("tr");
             Element th = new Element("th"); 
@@ -72,9 +72,11 @@ public class TooltipRenderer {
             element.appendNonBreakingSpace();
             element.appendSister(tooltip);
         }
+
+        return tooltip;
     }
     
-   private Element createTooltip(String relativePathToImage, String text) {
+   private Element createTooltip(String relativePathToImage, String text, boolean displayTooltip) {
         Element tt = new Element("a").addAttribute("href", "#").addStyleClass("tt");
         tt.appendChild(new Element("img").addAttribute("src", relativePathToImage).addAttribute("alt", "i").appendNonBreakingSpace());
         Element tooltip = new Element("span").addStyleClass("tooltip");
@@ -88,6 +90,18 @@ public class TooltipRenderer {
         tooltip.appendChild(textChild);
         tooltip.appendChild(new Element("span").addStyleClass("bottom").appendText(""));
         
+        if(!displayTooltip) {
+            setTooltipDisplay(tt, false);
+        }
+        
         return tt;
     }
+
+   public void setTooltipDisplay(Element tooltip, boolean displayed) {
+	   if(!displayed) {
+		   tooltip.addAttribute("style", "display: none;");
+	   } else {
+		   tooltip.removeAttribute("style");
+	   }
+   }
 }

--- a/src/main/resources/org/concordion/ext/resource/tooltip.js
+++ b/src/main/resources/org/concordion/ext/resource/tooltip.js
@@ -1,0 +1,10 @@
+function toggleTooltip() {
+    var tooltips = document.getElementsByClassName('tt');
+    for(var i=0; i<tooltips.length; i++) {
+        if(tooltips[i].style.display == 'none') {
+            tooltips[i].style.display = 'inline';
+        } else {
+            tooltips[i].style.display = 'none';
+        }
+    }
+}

--- a/src/test/java/spec/concordion/ext/loggingTooltip/LoggingTooltipJs.java
+++ b/src/test/java/spec/concordion/ext/loggingTooltip/LoggingTooltipJs.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010 Two Ten Consulting Limited, New Zealand 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spec.concordion.ext.loggingTooltip;
+
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+import test.concordion.FileOutputStreamer;
+import test.concordion.ProcessingResult;
+import test.concordion.TestRig;
+
+@RunWith(ConcordionRunner.class)
+public class LoggingTooltipJs {
+    
+    public void setSystemProperty(String name, String value) {
+        System.setProperty(name, value);
+    }
+    
+    public boolean hasJSDeclaration(String jsFilename) throws Exception {
+        ProcessingResult result = new TestRig()
+            .withFixture(this)
+            .withOutputStreamer(new FileOutputStreamer())
+            .withSourceFilter("/org/concordion/ext/resource")
+            .processFragment("");
+        return result.hasJavaScriptDeclaration(jsFilename);
+    }
+}

--- a/src/test/resources/spec/concordion/ext/loggingTooltip/LoggingTooltipJs.html
+++ b/src/test/resources/spec/concordion/ext/loggingTooltip/LoggingTooltipJs.html
@@ -1,0 +1,33 @@
+<!-- 
+Copyright (c) 2010 Two Ten Consulting Limited, New Zealand
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+<html xmlns:concordion="http://www.concordion.org/2007/concordion" xmlns:cx="urn:concordion-extensions:2010">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+  <h1>Logging Tooltip JS Code</h1>
+
+  <p>The Logging Tooltip extension adds an external JS file.</p>
+  
+  <div class="example">
+        <h3>Example</h3>
+        
+        <p concordion:execute="setSystemProperty(#name, #value)">Given the system property <code concordion:set="#name">concordion.extensions</code> is set to <code concordion:set="#value">org.concordion.ext.LoggingTooltipExtension</code>.</p>
+        
+        <p>The HTML output links the external <span concordion:assertTrue="hasJSDeclaration(#TEXT)">tooltip.js</span> file.</p>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Now it is possible to show/hide tooltips with a button:

- In Java by implementing the `TooltipButton` interface (similar to a `Button` or a `JButton`)
```java
public class ToggleTooltipButton implements TooltipButton {
    // ...
}

@Extension
LoggingTooltipExtension extension = new LoggingTooltipExtension();

TooltipButton myButton = new ToggleTooltipButton();
extension.setTooltipButton(myButton);
```

- In JavaScript by calling the `toggleTooltip()` function on click of a button
```html
<input type="button" onclick="toggleTooltip();" value="Toggle tooltip" />
```

- Alternatively, by using Concordion and calling `toggleTooltip` method:
```html
<!-- In HTML:
    <span c:set="#tooltipHidden">true</span>
    <span c:execute="hideTooltip(#tooltipHidden)"></span>
-->
```
```java
// In Java:
public void hideTooltip(String tooltipHidden) {
    boolean displayTooltip = true;
    if(tooltipHidden != null) {
        // Tooltip is hidden only if param is set and not empty
        displayTooltip = tooltipHidden.isEmpty();
     }
     extension.toggleTooltip(displayTooltip);
}
```